### PR TITLE
Add GitHub Actions CI workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,46 @@
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - ci/**
+  workflow_dispatch:
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser dependencies
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: pnpm run e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - ci/**
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run lint
+        run: pnpm run lint:ci

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,34 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - ci/**
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm run test:ci

--- a/MVP_MILESTONES_6_9.md
+++ b/MVP_MILESTONES_6_9.md
@@ -317,6 +317,96 @@ Result: Strong improvement
 
 ---
 
+# Milestone 10 — CI/CD Setup with GitHub Actions
+
+## Goal
+
+Introduce reliable CI/CD quality gates with GitHub Actions so changes are automatically validated before merging.
+
+## Problems Being Solved
+
+Current workflow:
+
+Local commands only
+
+Issues:
+- No automated validation on pull requests
+- Regressions can merge without lint, unit, or e2e coverage running
+- Team quality checks depend on each developer remembering to run scripts locally
+
+## Required Features
+
+### GitHub Actions
+
+Add three separate GitHub Actions workflows:
+
+- Linting
+- Unit tests
+- E2E tests
+
+### Linting Workflow
+
+Runs:
+
+- `pnpm run lint:ci`
+
+Behavior:
+
+- Reports failures in GitHub Actions
+- Must not be configured as a required merge check
+
+### Unit Test Workflow
+
+Runs:
+
+- `pnpm run test:ci`
+
+Behavior:
+
+- Executes on pull requests and pushes
+- Must be configured as a required merge check
+
+### E2E Test Workflow
+
+Runs:
+
+- `pnpm run e2e`
+
+Behavior:
+
+- Installs Playwright browser dependencies
+- Starts the Angular app through the existing Playwright configuration
+- Must be configured as a required merge check
+
+### Merge Policy
+
+Branch protection on `main` must require:
+
+- Unit tests
+- E2E tests
+
+Branch protection on `main` must not require:
+
+- Linting
+
+## Deliverables
+
+- GitHub Actions workflow for linting
+- GitHub Actions workflow for unit tests
+- GitHub Actions workflow for e2e tests
+- Documented merge policy for required and optional checks
+
+## Acceptance Criteria
+
+- Pull requests automatically run lint, unit, and e2e workflows
+- `pnpm run lint:ci` runs in GitHub Actions and reports failures without being required for merge
+- `pnpm run test:ci` runs in GitHub Actions and can be marked as a required check
+- `pnpm run e2e` runs in GitHub Actions with Playwright browser installation and can be marked as a required check
+- Workflow setup uses pnpm consistently with the repository package manager
+- A maintainer can configure branch protection so only the unit and e2e checks block merges
+
+---
+
 # Long Term Vision
 
 After Milestone 9 the application becomes a tuning knowledge system.

--- a/e2e/graph-library.spec.ts
+++ b/e2e/graph-library.spec.ts
@@ -40,7 +40,9 @@ test('duplicates a saved graph and confirms delete flows from the library', asyn
   await originalCard.getByRole('button', { name: 'Duplicate' }).click();
   await expect(page).toHaveURL(/\/graphs\//);
   await expect(
-    page.getByRole('heading', { name: '2WD Buggy Carpet Baseline Copy' }).first(),
+    page
+      .getByRole('heading', { name: '2WD Buggy Carpet Baseline Copy' })
+      .first(),
   ).toBeVisible();
 
   await returnToLibrary(page);

--- a/src/app/features/import-export/data-access/import-validator.ts
+++ b/src/app/features/import-export/data-access/import-validator.ts
@@ -42,9 +42,9 @@ export class ImportValidator {
       'exportTimestamp',
       errors,
     );
-    const graph = readGraphRecord(candidate['graph'], 'graph', errors);
-    const nodes = readNodeRecords(candidate['nodes'], 'nodes', errors);
-    const edges = readEdgeRecords(candidate['edges'], 'edges', errors);
+    const graph = readGraphRecord(candidate.graph, 'graph', errors);
+    const nodes = readNodeRecords(candidate.nodes, 'nodes', errors);
+    const edges = readEdgeRecords(candidate.edges, 'edges', errors);
 
     if (schemaVersion !== GRAPH_SCHEMA_VERSION) {
       errors.push(
@@ -273,9 +273,9 @@ function readNodeRecord(
       `${path}.confidence`,
       errors,
     ) as GraphNodeRecord['confidence'],
-    position: readPosition(candidate['position'], `${path}.position`, errors),
-    size: readOptionalSize(candidate['size'], `${path}.size`, errors),
-    data: readDataRecord(candidate['data'], `${path}.data`, errors),
+    position: readPosition(candidate.position, `${path}.position`, errors),
+    size: readOptionalSize(candidate.size, `${path}.size`, errors),
+    data: readDataRecord(candidate.data, `${path}.data`, errors),
     createdAt: readRequiredString(
       candidate,
       'createdAt',

--- a/src/app/features/shell/placeholder-page/placeholder-page.ts
+++ b/src/app/features/shell/placeholder-page/placeholder-page.ts
@@ -19,7 +19,7 @@ export class PlaceholderPage {
   private readonly route = inject(ActivatedRoute);
 
   protected readonly title = toSignal(
-    this.route.data.pipe(map((d) => (d['title']as string) ?? '')),
+    this.route.data.pipe(map((d) => (d.title as string) ?? '')),
     { initialValue: '' },
   );
 }


### PR DESCRIPTION
## Summary
- add Milestone 10 for CI/CD setup with GitHub Actions
- add separate lint, unit test, and e2e workflows using the repo pnpm scripts
- keep lint optional for merge policy and document unit/e2e as required checks
- fix existing Biome issues so the new lint workflow starts green

## Validation
- pnpm run lint:ci
- pnpm run test:ci
- pnpm run e2e